### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/smartpot/com/api/Security/Config/SecurityConfiguration.java
+++ b/src/main/java/smartpot/com/api/Security/Config/SecurityConfiguration.java
@@ -59,7 +59,7 @@ public class SecurityConfiguration {
         }
 
         return httpSec
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(Customizer.withDefaults()) // Enable CSRF protection
                 .cors(c -> c.configurationSource(corsConfig))
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry -> {
                     authorizationManagerRequestMatcherRegistry.requestMatchers(publicRoutesList.toArray(new String[0])).permitAll();


### PR DESCRIPTION
Potential fix for [https://github.com/SmartPotTech/SmartPot-API/security/code-scanning/5](https://github.com/SmartPotTech/SmartPot-API/security/code-scanning/5)

To fix the issue, CSRF protection should be enabled by default. This involves removing the line that disables CSRF protection (`httpSec.csrf(AbstractHttpConfigurer::disable)`) and allowing Spring Security to manage CSRF tokens automatically. If there are specific endpoints that do not require CSRF protection (e.g., public APIs), they can be explicitly excluded using Spring's `csrf().ignoringRequestMatchers()` configuration.

**Steps to fix:**
1. Remove the `httpSec.csrf(AbstractHttpConfigurer::disable)` line from the `securityFilterChain` method.
2. Optionally, configure CSRF protection to ignore specific endpoints if necessary using `csrf().ignoringRequestMatchers()`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
