### PR TITLE
Potential fix for code scanning alert no. 3: Overly permissive regular expression range

### DIFF
--- a/src/main/java/smartpot/com/api/Users/Validator/UserRegex.java
+++ b/src/main/java/smartpot/com/api/Users/Validator/UserRegex.java
@@ -16,7 +16,7 @@ public class UserRegex {
      * incluyendo caracteres acentuados y especiales. La longitud debe ser de 4 a 15 caracteres.
      * </p>
      */
-    public static final String NAME_PATTERN = "^[a-zA-ZÁ-ÿá-ÿ]{4,15}$";
+    public static final String NAME_PATTERN = "^[a-zA-ZÁ-Úá-ú]{4,15}$";
 
     /**
      * Expresión regular para validar el apellido de un usuario.
@@ -25,7 +25,7 @@ public class UserRegex {
      * incluyendo caracteres acentuados y especiales. La longitud debe ser de 4 a 30 caracteres.
      * </p>
      */
-    public static final String LASTNAME_PATTERN = "^[a-zA-ZÁ-ÿá-ÿ]{4,30}$";
+    public static final String LASTNAME_PATTERN = "^[a-zA-ZÁ-Úá-ú]{4,30}$";
 
     /**
      * Expresión regular para validar la dirección de correo electrónico de un usuario.


### PR DESCRIPTION
Potential fix for [https://github.com/SmartPotTech/SmartPot-API/security/code-scanning/3](https://github.com/SmartPotTech/SmartPot-API/security/code-scanning/3)

To fix the issue, the overly permissive range `Á-ÿ` should be replaced with a more precise range that matches only alphabetic characters. This can be achieved by explicitly listing the ranges for uppercase (`Á-Ú`) and lowercase (`á-ú`) accented characters, ensuring that non-alphabetic characters are excluded.

The changes should be applied to both `NAME_PATTERN` and `LASTNAME_PATTERN` constants in the `UserRegex` class. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
