### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   deployment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SmartPotTech/SmartPot-API/security/code-scanning/1](https://github.com/SmartPotTech/SmartPot-API/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow does not appear to require write access to the repository, we can set `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit these minimal permissions unless explicitly overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
