### PR TITLE
Potential fix for code scanning alert no. 6: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/smartpot/com/api/Security/Config/SecurityConfiguration.java
+++ b/src/main/java/smartpot/com/api/Security/Config/SecurityConfiguration.java
@@ -59,7 +59,7 @@ public class SecurityConfiguration {
         }
 
         return httpSec
-                .csrf(AbstractHttpConfigurer::disable) // Enable CSRF protection
+                .csrf(Customizer.withDefaults()) // Enable CSRF protection
                 .cors(cors -> cors.configurationSource(corsConfig))
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry -> {
                     authorizationManagerRequestMatcherRegistry.requestMatchers(publicRoutesList.toArray(new String[0])).permitAll();


### PR DESCRIPTION
Potential fix for [https://github.com/SmartPotTech/SmartPot-API/security/code-scanning/6](https://github.com/SmartPotTech/SmartPot-API/security/code-scanning/6)

To fix the issue, CSRF protection should be enabled by removing the `AbstractHttpConfigurer::disable` call. This ensures that Spring Security's default CSRF protection is applied. If certain endpoints need to bypass CSRF protection (e.g., for APIs), specific configurations can be added to exempt those endpoints while keeping protection enabled for others.

**Steps to fix:**
1. Remove the `AbstractHttpConfigurer::disable` call from the `csrf` configuration in the `securityFilterChain` method.
2. Optionally, configure CSRF protection to exempt specific endpoints if necessary using `csrf().ignoringRequestMatchers(...)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
