### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,10 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/SmartPotTech/SmartPot-API/security/code-scanning/7](https://github.com/SmartPotTech/SmartPot-API/security/code-scanning/7)

The best way to fix the problem is to add a `permissions` block to the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. The permissions should be set to the minimum required for the workflow's operations. Based on the workflow's steps, the following permissions are likely required:
- `contents: read` for accessing the repository contents during the `checkout` step.
- `security-events: write` for uploading SARIF results to the security tab in GitHub.

The `permissions` block should be added at the root level of the workflow, applying to all jobs unless overridden in individual job blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
